### PR TITLE
Wifi controller code cleaning

### DIFF
--- a/main/ui/tile-channels.c
+++ b/main/ui/tile-channels.c
@@ -195,12 +195,8 @@ int channels_tile_event_handler(tile_t *p_tile, tile_event_t event, int x, int y
   {
     case TE_ENTER:
       {
-        /* Check if wifi is set in scanner mode. */
-        if (wifi_get_mode() != WIFI_SNIFFER)
-        {
-          /* Enable scanner. */
-          wifi_set_mode(WIFI_SNIFFER);
-        }
+        /* Enable scanner. */
+        wifi_set_mode(WIFI_SNIFFER);
 
         /* Set channel. */
         g_channel = 1;

--- a/main/ui/tile-rogueap.c
+++ b/main/ui/tile-rogueap.c
@@ -5,7 +5,6 @@ widget_label_t title_lbl, target_lbl, essid_lbl, channel_lbl;
 widget_button_t select_btn, startstop_btn;
 
 /* AP selection. */
-bool b_rogueap_enabled = false;
 modal_t ap_select_modal;
 wifiscan_t ap_wifiscan;
 widget_button_t ap_select_ok_btn;
@@ -20,12 +19,8 @@ int rogueap_tile_event_handler(tile_t *p_tile, tile_event_t event, int x, int y,
   {
     case TE_ENTER:
       {
-        /* Check if wifi is set in scanner mode. */
-        if (wifi_get_mode() != WIFI_SCANNER)
-        {
-          /* Enable scanner. */
-          wifi_set_mode(WIFI_SCANNER);
-        }
+        /* Enable scanner. */
+        wifi_set_mode(WIFI_SCANNER);
       }
       break;
 
@@ -52,13 +47,12 @@ void select_btn_onclick(struct widget_t *p_widget)
 
 void start_btn_onclick(struct widget_t *p_widget)
 {
-  if (!b_rogueap_enabled)
+  if (wifi_get_mode() != WIFI_ROGUEAP)
   {
     if (target_ap != NULL)
     {
       printf("Starting rogue AP for %s\r\n", target_ap->essid);
       widget_button_set_text(&startstop_btn, "Stop");
-      b_rogueap_enabled = true;
       wifi_rogueap_set_target(target_ap);
     }
     else
@@ -68,13 +62,8 @@ void start_btn_onclick(struct widget_t *p_widget)
   }
   else
   {
-    /* Check if wifi is set in scanner mode. */
-    if (wifi_get_mode() != WIFI_SCANNER)
-    {
-      /* Enable scanner. */
-      wifi_set_mode(WIFI_SCANNER);
-    }
-    b_rogueap_enabled = false;
+    /* Enable scanner. */
+    wifi_set_mode(WIFI_SCANNER);
     widget_button_set_text(&startstop_btn, "Start");
   }
 }

--- a/main/ui/tile-scanner.c
+++ b/main/ui/tile-scanner.c
@@ -28,12 +28,8 @@ int scanner_tile_event_handler(tile_t *p_tile, tile_event_t event, int x, int y,
   {
     case TE_ENTER:
       {
-        /* Check if wifi is set in scanner mode. */
-        if (wifi_get_mode() != WIFI_SCANNER)
-        {
-          /* Enable scanner. */
-          wifi_set_mode(WIFI_SCANNER);
-        }
+        /* Enable scanner. */
+        wifi_set_mode(WIFI_SCANNER);
       }
       break;
 

--- a/main/wifi/wifi.c
+++ b/main/wifi/wifi.c
@@ -127,6 +127,10 @@ void wifi_enable(wifi_driver_mode_t mode)
 
 void wifi_disable()
 {
+    /* Sanity check. */
+  if (!g_wifi_ctrl.b_enabled)
+    return;
+
   /* Disable WiFi. */
   g_wifi_ctrl.driver_mode = WIFI_DRIVER_OFF;
   ESP_ERROR_CHECK(esp_wifi_stop());
@@ -251,11 +255,7 @@ void wifi_rogueap_disable(void)
   vTaskDelete(g_wifi_ctrl.current_task_handle);
 
   /* Stop WiFi. */
-  if (g_wifi_ctrl.b_enabled)
-  {
-    wifi_disable();
-    g_wifi_ctrl.b_enabled = false;
-  }
+  wifi_disable();
 }
 
 
@@ -369,11 +369,7 @@ void wifi_sniffer_disable(void)
   esp_wifi_set_promiscuous(false);
 
   /* Stop WiFi. */
-  if (g_wifi_ctrl.b_enabled)
-  {
-    wifi_disable();
-    g_wifi_ctrl.b_enabled = false;
-  }
+  wifi_disable();
 }
 
 
@@ -461,11 +457,7 @@ void wifi_deauth_disable(void)
   vTaskDelete(g_wifi_ctrl.current_task_handle);
 
   /* Stop WiFi. */
-  if (g_wifi_ctrl.b_enabled)
-  {
-    wifi_disable();
-    g_wifi_ctrl.b_enabled = false;
-  }
+  wifi_disable();
 }
 
 
@@ -507,11 +499,7 @@ void wifi_scanner_disable(void)
   esp_wifi_scan_stop();
 
   /* Stop WiFi. */
-  if (g_wifi_ctrl.b_enabled)
-  {
-    wifi_disable();
-    g_wifi_ctrl.b_enabled = false;
-  }
+  wifi_disable();
 
   /* Stop our scanner task. */
   vTaskDelete(g_wifi_ctrl.current_task_handle);
@@ -527,10 +515,7 @@ void wifi_scanner_disable(void)
 void wifi_scanner_enable(void)
 {
   /* Enable WiFi if disabled. */
-  if (!g_wifi_ctrl.b_enabled)
-  {
-    wifi_enable(WIFI_DRIVER_STA);
-  }
+  wifi_enable(WIFI_DRIVER_STA);
 
   /* Configure scanner. */
   memset(&g_wifi_ctrl.scan_config, 0, sizeof(wifi_scan_config_t));
@@ -737,6 +722,10 @@ void wifi_set_sniffer_handler(FWifiPacketReceivedCb callback)
 
 void wifi_set_mode(wifi_controller_mode_t mode)
 {
+  /* Sanity check */
+  if (wifi_get_mode() == mode)
+    return;
+
   ESP_LOGI(TAG, "set mode to %d", mode);
   ESP_LOGD(TAG, "disabling old mode (%d) ...", g_wifi_ctrl.mode);
 


### PR DESCRIPTION
Hi Virtualabs,
Thank you again for the Twitch live of last night.
I made some modification on the wifi part which allows to simplify the code and reduce the redundancy.
I also use the wifi_get_mode function to change the status of the start button of the RogueAp tile instead of the boolean b_rogueap_enabled.

So much for the changes, tell me what you think ;)